### PR TITLE
Require google.cloud collection

### DIFF
--- a/molecule_gce/driver.py
+++ b/molecule_gce/driver.py
@@ -17,6 +17,7 @@
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
+from typing import Dict
 import os
 from molecule import logger
 from molecule.api import Driver
@@ -168,3 +169,7 @@ class GCE(Driver):
         command in order to figure out where to load the templates from.
         """
         return os.path.join(os.path.dirname(__file__), "cookiecutter")
+
+    def required_collections(self) -> Dict[str, str]:
+        # https://galaxy.ansible.com/google/cloud
+        return {"google.cloud": "1.0.2"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    molecule >= 3.2.0a0
+    molecule >= 3.4.0
     pyyaml >= 5.1, < 6
 
 [options.extras_require]


### PR DESCRIPTION
This will ensure that we have the required collection installed when we try to run a scenario using this driver. Molecule will know to install the collection when needed.

Fixes: #3 