### PR TITLE
Add preemptible feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ platforms:
   - name: ubuntu-instance-created-by-molecule  #  REQUIRED: this will be your VM name
     zone: us-central1-a  # Example: us-west1-b. Will default to zone b of region defined in driver (some regions do not have a zone-a)
     machine_type: n1-standard-1  # If not specified, will default to n1-standard-1
+    preemptible: false  # If not specified, will default to false. Preemptible instances have no SLA, in case of resource shortage in the zone they might get destroyed (or not be created) without warning, and will always be terminated after 24 hours. But they cost less and will mitigate the financial consequences of a PAYG licenced VM that would be forgotten.
     image: 'projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts'  # Points to an image, you can get a list of available images with command 'gcloud compute images list'.
        # The expected format of this string is projects/<project>/global/images/family/<family-name>
        # (see https://googlecloudplatform.github.io/compute-image-tools/daisy-automating-image-creation.html)

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,6 +18,7 @@ driver:
 platforms:
   - name: instance  # REQUIRED is an instance name
     machine_type: null  # If not specified, will default to n1-standard-1
+    preemptible: false  # Preemptible VMs are cheaper but not guaranteed to live long (or at all), and will terminate after 24hours.
     zone: null  # example: us-west1-b, will default to zone b of driver.region
     disk_size_gb: null  # Set only if needed
     image: 'projects/debian-cloud/global/images/family/debian-10'  # Points to an image, you can get a list of available images with command 'gcloud compute images list'.

--- a/src/molecule_gce/playbooks/tasks/create_linux_instance.yml
+++ b/src/molecule_gce/playbooks/tasks/create_linux_instance.yml
@@ -12,6 +12,8 @@
     machine_type: "{{ item.machine_type | default('n1-standard-1') }}"
     metadata:
       ssh-keys: "{{ lookup('env','USER') }}:{{ keypair.public_key }}}"
+    scheduling:
+      preemptible: "{{ item.preemptible | default(false) }}"
     disks:
       - auto_delete: true
         boot: true

--- a/src/molecule_gce/playbooks/tasks/create_windows_instance.yml
+++ b/src/molecule_gce/playbooks/tasks/create_windows_instance.yml
@@ -4,6 +4,8 @@
     state: present
     name: "{{ item.name }}"
     machine_type: "{{ item.machine_type | default('n1-standard-1') }}"
+    scheduling:
+      preemptible: "{{ item.preemptible | default(false) }}"
     disks:
       - auto_delete: true
         boot: true


### PR DESCRIPTION
* Adds boolean parameter "preemptible" to be set in platforms. As Molecule instances are often short lived instances this will allow to mitigate the financial consequences of a forgoten running instance (particularly for pay-as-you-go licenced VMs, such as Windows or SLES/RHEL).
* Modifies Readme to describe the parameter