### PR TITLE
Pass selfLink to netwrok and subnetwork rather then get network information

### DIFF
--- a/src/molecule_gce/playbooks/create.yml
+++ b/src/molecule_gce/playbooks/create.yml
@@ -16,35 +16,6 @@
             molecule_yml.driver.instance_os_type | lower == "windows"
         fail_msg: "instance_os_type is possible only to specify linux or windows either"
 
-    - name: get network info
-      google.cloud.gcp_compute_network_info:
-        filters:
-          - name = "{{ molecule_yml.driver.network_name | default('default') }}"
-        project: "{{ molecule_yml.driver.vpc_host_project | default(gcp_project_id) }}"
-        service_account_email: "{{ molecule_yml.driver.service_account_email | default (omit, true) }}"
-        service_account_file: "{{ molecule_yml.driver.service_account_file | default (omit, true) }}"
-        auth_kind: "{{ molecule_yml.driver.auth_kind | default(omit, true) }}"
-      register: my_network
-
-    - name: get subnetwork info
-      google.cloud.gcp_compute_subnetwork_info:
-        filters:
-          - name = "{{ molecule_yml.driver.subnetwork_name | default('default') }}"
-        project: "{{ molecule_yml.driver.vpc_host_project | default(gcp_project_id) }}"
-        region: "{{ molecule_yml.driver.region }}"
-        service_account_email: "{{ molecule_yml.driver.service_account_email | default (omit, true) }}"
-        service_account_file: "{{ molecule_yml.driver.service_account_file | default (omit, true) }}"
-        auth_kind: "{{ molecule_yml.driver.auth_kind | default(omit, true) }}"
-      register: my_subnetwork
-
-    - name: set external access config
-      set_fact:
-        external_access_config:
-          - access_configs:
-              - name: "External NAT"
-                type: "ONE_TO_NAT"
-      when: molecule_yml.driver.external_access
-
     - name: Include create_linux_instance tasks
       include_tasks: tasks/create_linux_instance.yml
       when:

--- a/src/molecule_gce/playbooks/tasks/create_linux_instance.yml
+++ b/src/molecule_gce/playbooks/tasks/create_linux_instance.yml
@@ -22,7 +22,12 @@
           source_image: "{{ item.image | default('projects/debian-cloud/global/images/family/debian-10') }}"
           source_image_encryption_key:
             raw_key: "{{ item.image_encryption_key | default(omit) }}"
-    network_interfaces: "{{ [ { 'network': my_network.resources.0 | default(omit), 'subnetwork': my_subnetwork.resources.0 | default(omit) } | combine(external_access_config | default([]) ) ] }}"
+    network_interfaces:
+      - network:
+          selfLink: "https://www.googleapis.com/compute/v1/projects/{{ molecule_yml.driver.vpc_host_project | default(gcp_project_id) }}/global/networks/{{ molecule_yml.driver.network_name | default('default') }}"
+        subnetwork:
+          selfLink: "https://compute.googleapis.com/compute/v1/projects/{{ molecule_yml.driver.vpc_host_project | default(gcp_project_id) }}/regions/{{ molecule_yml.driver.region }}/subnetworks/{{ molecule_yml.driver.subnetwork_name | default('default') }}"
+        access_configs: "{{ [{'name': 'instance_ip', 'type': 'ONE_TO_ONE_NAT'}] if molecule_yml.driver.external_access else [] }}"
     zone: "{{ item.zone | default(molecule_yml.driver.region + '-b') }}"
     project: "{{ gcp_project_id }}"
     scopes: "{{ molecule_yml.driver.scopes | default(['https://www.googleapis.com/auth/compute'], True) }}"

--- a/src/molecule_gce/playbooks/tasks/create_windows_instance.yml
+++ b/src/molecule_gce/playbooks/tasks/create_windows_instance.yml
@@ -14,7 +14,12 @@
           source_image: "{{ item.image | default('projects/windows-cloud/global/images/family/windows-2019') }}"
           source_image_encryption_key:
             raw_key: "{{ item.image_encryption_key | default(omit) }}"
-    network_interfaces: "{{ [ { 'network': my_network.resources.0 | default(omit), 'subnetwork': my_subnetwork.resources.0 | default(omit) } | combine(external_access_config | default([])) ] }}"
+    network_interfaces:
+      - network:
+          selfLink: "https://www.googleapis.com/compute/v1/projects/{{ molecule_yml.driver.vpc_host_project | default(gcp_project_id) }}/global/networks/{{ molecule_yml.driver.network_name | default('default') }}"
+        subnetwork:
+          selfLink: "https://compute.googleapis.com/compute/v1/projects/{{ molecule_yml.driver.vpc_host_project | default(gcp_project_id) }}/regions/{{ molecule_yml.driver.region }}/subnetworks/{{ molecule_yml.driver.subnetwork_name | default('default') }}"
+        access_configs: "{{ [{'name': 'instance_ip', 'type': 'ONE_TO_ONE_NAT'}] if molecule_yml.driver.external_access else [] }}"
     zone: "{{ item.zone | default(molecule_yml.driver.region + '-b') }}"
     project: "{{ gcp_project_id }}"
     scopes: "{{ molecule_yml.driver.scopes | default(['https://www.googleapis.com/auth/compute'], True) }}"


### PR DESCRIPTION
## Summary

This PR is the continuation of a discussion started in this #20. We tested the code as requested and We found a possible fix. 

## Problem 
We get this error when using the driver because we haven't read/list access to shared VPC.
```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "GCP returned error: {'error': {'code': 403, 'message': \"Required 'compute.networks.list' permission for 'projects/vg1np-core-apps7-90'\", 'errors': [{'message': \"Required 'compute.networks.list' permission for 'projects/vg1np-core-apps7-90'\", 'domain': 'global', 'reason': 'forbidden'}]}}"}
```
## Solution
After a lot of search in the `google.cloud.gcp_compute_instance`, we found that the `network` object use `selfLink` attribute to attach the instance to the network. So, We think it is better to pass the network configuration to the instance using the `selfLink` rather than get network information that needs permissions to do.



