### PR TITLE
remove additional bracket

### DIFF
--- a/src/molecule_gce/playbooks/tasks/create_linux_instance.yml
+++ b/src/molecule_gce/playbooks/tasks/create_linux_instance.yml
@@ -11,7 +11,7 @@
     name: "{{ item.name }}"
     machine_type: "{{ item.machine_type | default('n1-standard-1') }}"
     metadata:
-      ssh-keys: "{{ lookup('env','USER') }}:{{ keypair.public_key }}}"
+      ssh-keys: "{{ lookup('env','USER') }}:{{ keypair.public_key }}"
     scheduling:
       preemptible: "{{ item.preemptible | default(false) }}"
     disks:


### PR DESCRIPTION
## Bug

There is an additional Bracket that is introduced in the instance SSH public key association that fails the SSH connection to the instance.
```yaml
    metadata:
      ssh-keys: "{{ lookup('env','USER') }}:{{ keypair.public_key }}}"
```
## Additional information
Molecule version

```
molecule 3.4.0 using python 3.9 
    ansible:2.11.3
    delegated:3.4.0 from molecule
    docker:0.2.4 from molecule_docker
    ec2:0.3 from molecule_ec2
    gce:0.3.dev12+g1d3d363 from molecule_gce requiring collections: google.cloud>=1.0.2
```
