### PR TITLE
Drop support for python 3.6 and python 3.7

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,13 +21,9 @@ jobs:
         include:
           - tox_env: lint
           # - tox_env: docs
-          - tox_env: py36
-            PREFIX: PYTEST_REQPASS=3
-          - tox_env: py36-devel
-            PREFIX: PYTEST_REQPASS=3
-          - tox_env: py37
-            PREFIX: PYTEST_REQPASS=3
           - tox_env: py38
+            PREFIX: PYTEST_REQPASS=3
+          - tox_env: py38-devel
             PREFIX: PYTEST_REQPASS=3
           - tox_env: py39
             PREFIX: PYTEST_REQPASS=3

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,6 @@ classifiers =
     Natural Language :: English
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
 
@@ -48,7 +46,7 @@ keywords =
 
 [options]
 use_scm_version = True
-python_requires = >=3.6
+python_requires = >=3.8
 package_dir =
   = src
 packages = find:

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ minversion = 3.9.0
 envlist =
     lint
     packaging
-    py{36,37,38,39}
-    py{36,37,38,39}-{devel}
+    py{38,39}
+    py{38,39}-{devel}
 
 # do not enable skip missing to avoid CI false positives
 skip_missing_interpreters = False
@@ -20,11 +20,11 @@ download = true
 # sitepackages = True
 extras = test
 deps =
-    py{36,37,38,39}: molecule[test]
-    py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@main#egg=molecule[test]
-    py{36,37,38,39}: google-api-python-client
-    py{36,37,38,39}: oauth2client
-    py{36,37,38,39}: pycryptodome
+    py{38,39}: molecule[test]
+    py{38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@main#egg=molecule[test]
+    py{38,39}: google-api-python-client
+    py{38,39}: oauth2client
+    py{38,39}: pycryptodome
 commands =
     pytest --collect-only
     pytest --color=yes {tty:-s}


### PR DESCRIPTION
Python 3.8 or higher is now required.