### PR TITLE
Switch to packaging to `build`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,6 @@ requires = [
   "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+local_scheme = "no-local-version"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[aliases]
-dists = clean --all sdist bdist_wheel
-
 [metadata]
 name = molecule-gce
 url = https://github.com/ansible-community/molecule-gce
@@ -11,8 +8,8 @@ project_urls =
     Discussions = https://github.com/ansible-community/molecule/discussions
     Source Code = https://github.com/ansible-community/molecule-gce
 description = Molecule GCE Plugin :: run molecule tests on Google Cloud Engine
-long_description = file: README.rst
-long_description_content_type = text/x-rst
+long_description = file: README.md
+long_description_content_type = text/markdown
 author = Ansible by Red Hat
 author_email = info@ansible.com
 maintainer = Ansible by Red Hat
@@ -52,11 +49,6 @@ package_dir =
 packages = find:
 include_package_data = True
 zip_safe = False
-
-# These are required during `setup.py` run:
-setup_requires =
-    setuptools_scm >= 1.15.0
-    setuptools_scm_git_archive >= 1.0
 
 # These are required in actual runtime:
 install_requires =

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-# !/usr/bin/env python
-import setuptools
-
-
-if __name__ == "__main__":
-    setuptools.setup(use_scm_version=True)

--- a/tox.ini
+++ b/tox.ini
@@ -58,26 +58,27 @@ passenv =
     TRAVIS_*
     TWINE_*
 whitelist_externals =
-    bash
+    rm
     twine
     pytest
     pre-commit
 
 [testenv:packaging]
+description =  Build package, verify metadata, install package.
+# `usedevelop = true` overrides `skip_install` instruction, it's unwanted
 usedevelop = false
 skip_install = true
 deps =
-    collective.checkdocs >= 0.2
-    pep517 >= 0.5.0
-    twine >= 2.0.0
+    build >= 0.7.0, < 0.8.0
+    twine
 commands =
-    bash -c "rm -rf {toxinidir}/dist/ && mkdir -p {toxinidir}/dist/"
-    python -m pep517.build \
-      --source \
-      --binary \
-      --out-dir {toxinidir}/dist/ \
+    # build wheel and sdist using PEP-517
+    rm -rfv {toxinidir}/dist/
+    python -m build \
+      --outdir {toxinidir}/dist/ \
       {toxinidir}
-    twine check dist/*
+    # metadata validation
+    twine check --strict {toxinidir}/dist/*
 
 [testenv:lint]
 description = Performs linting, style checks

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ passenv =
     TRAVIS
     TRAVIS_*
     TWINE_*
-whitelist_externals =
+allowlist_externals =
     rm
     twine
     pytest


### PR DESCRIPTION
Switching from pep517.build to build because pep517 is deprecated and also use allowlist_externals instead of whitelist_externals for `tox.ini`

This PR is based on #45, which should be merge first.