### PR TITLE
Accepts service account definition the created VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ driver:
   external_access: false  # chose whether to create a public IP for the VM or not - default is private IP only
   instance_os_type: linux  # Either windows or linux. Will be considered linux by default. You can NOT mix Windows and Linux VMs in the same scenario.
 platforms:
+  # see src/molecule_gce/playbooks/tasks/create_linux_instance.yml for a complete list of supported keys
   - name: ubuntu-instance-created-by-molecule  #  REQUIRED: this will be your VM name
     zone: us-central1-a  # Example: us-west1-b. Will default to zone b of region defined in driver (some regions do not have a zone-a)
     machine_type: n1-standard-1  # If not specified, will default to n1-standard-1

--- a/src/molecule_gce/playbooks/tasks/create_linux_instance.yml
+++ b/src/molecule_gce/playbooks/tasks/create_linux_instance.yml
@@ -30,6 +30,24 @@
         access_configs: "{{ [{'name': 'instance_ip', 'type': 'ONE_TO_ONE_NAT'}] if molecule_yml.driver.external_access else [] }}"
     tags: "{{ item.tags | default(omit) }}"
     zone: "{{ item.zone | default(molecule_yml.driver.region + '-b') }}"
+    service_accounts: >-
+      [
+        {% for account in molecule_yml.driver.service_accounts | d([]) %}
+          {
+            {% if account.email == 'same-as-driver' and molecule_yml.driver.service_account_email is defined %}
+              'email': '{{ molecule_yml.driver.service_account_email }}',
+            {% elif account.email == 'same-as-driver' and molecule_yml.driver.service_account_file is defined %}
+              'email': '{{ (lookup('file', molecule_yml.driver.service_account_file) | from_json)['client_email'] }}',
+            {% else %}
+              'email': '{{ account.email }}',
+            {% endif %}
+
+            {% if account.scopes is defined %}
+              'scopes': {{ account.scopes }},
+            {% endif %}
+          },
+        {% endfor %}
+      ]
     project: "{{ gcp_project_id }}"
     scopes: "{{ molecule_yml.driver.scopes | default(['https://www.googleapis.com/auth/compute'], True) }}"
     service_account_email: "{{ molecule_yml.driver.service_account_email | default (omit, true) }}"


### PR DESCRIPTION
Setting the service account that the VM itself will use (as well as the scope) is useful if the user wants to interact with google cloud apis from inside that VM. This PR makes it possible to define a service account (replicating the `service_accounts` field of the [gcp_compute_instance module](https://docs.ansible.com/ansible/devel/collections/google/cloud/gcp_compute_instance_module.html#ansible-collections-google-cloud-gcp-compute-instance-module)). There are three ways to define it:

- supply the service account email directly as a hardcoded value
- use the value of `same-as-driver` which:
  - will read the service account email from the json file defined in the `service_account_file` key of the driver configuration,
  - or will reuse the value of the `service_account_email` key of the driver configuration if that key is set.

This is done in order to allow the user to be more flexible without repeating themselves as well as allowing them to write reusable molecule.yml files independent of a specific project.